### PR TITLE
Removed unneeded group adding

### DIFF
--- a/spamassassin/Dockerfile
+++ b/spamassassin/Dockerfile
@@ -8,8 +8,7 @@ RUN apt-get update && \
     pyzor \
     razor \
     spamass-milter && \
-    rm -rf /var/lib/apt/lists/* \
-    adduser spamass-milter debian-spamd
+    rm -rf /var/lib/apt/lists/*
 
 COPY rootfs/ /
 


### PR DESCRIPTION
spamassassin:
- Obviously it's not required to add spamass-milter to the debian-spamd group ;-)