### PR TITLE
Update docker-compose file version

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
   mda:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
   test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
   # Creates self signed tls certificates. Remove if you


### PR DESCRIPTION
The updated file version makes it possible to define custom network names (in the override file).
https://docs.docker.com/compose/networking/#specify-custom-networks

I've chosen the lowest possible version to allow for the widest compatibility as possible.