### PR TITLE
Add redis service and redis configuration to be used in the filter service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,8 +87,11 @@ services:
       - data-virusdb:/var/lib/clamav
 
   redis:
-    image: redis
+    image: redis:alpine
     restart: on-failure:5
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - data-redis:/data
 
   # If you want unhealthy containers to be restarted automatically
   # just uncomment the following lines.
@@ -117,3 +120,4 @@ volumes:
   data-tls:
   data-filter:
   data-virusdb:
+  data-redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,10 @@ services:
     volumes:
       - data-virusdb:/var/lib/clamav
 
+  redis:
+    image: redis
+    restart: on-failure:5
+
   # If you want unhealthy containers to be restarted automatically
   # just uncomment the following lines.
   # autoheal:

--- a/filter/rootfs/etc/rspamd/override.d/redis.conf
+++ b/filter/rootfs/etc/rspamd/override.d/redis.conf
@@ -1,0 +1,1 @@
+servers = "redis";


### PR DESCRIPTION
I had the impression the junk wasn't learned from by rspamd, so I dived into the logs and configuration of the filter service. I believe the filter container is missing a redis instance to write the bayes data. 

`cfg; rspamd_redis_init: cannot init redis backend for BAYES_SPAM`



