### PR TITLE
Added possibility to change servicenames/hosts

### DIFF
--- a/filter/Dockerfile
+++ b/filter/Dockerfile
@@ -10,6 +10,7 @@ LABEL de.ressourcenkonflikt.docker-mailserver.autoheal="true"
 
 ENV FILTER_VIRUS=false \
     FILTER_VIRUS_HOST=virus.local \
+    REDIS_HOST=redis \
     WAITSTART_TIMEOUT=1m \
     CONTROLLER_PASSWORD=changeme
 

--- a/filter/rootfs/etc/rspamd/local.d/classifier-bayes.conf
+++ b/filter/rootfs/etc/rspamd/local.d/classifier-bayes.conf
@@ -1,3 +1,0 @@
-autolearn = true;
-servers = "redis";
-backend = "redis";

--- a/filter/rootfs/etc/rspamd/local.d/classifier-bayes.templ
+++ b/filter/rootfs/etc/rspamd/local.d/classifier-bayes.templ
@@ -1,0 +1,3 @@
+autolearn = true;
+servers = "{{$.Env.REDIS_HOST}}";
+backend = "{{$.Env.REDIS_HOST}}";

--- a/filter/rootfs/etc/rspamd/override.d/redis.conf
+++ b/filter/rootfs/etc/rspamd/override.d/redis.conf
@@ -1,1 +1,0 @@
-servers = "redis";

--- a/filter/rootfs/etc/rspamd/override.d/redis.templ
+++ b/filter/rootfs/etc/rspamd/override.d/redis.templ
@@ -1,0 +1,1 @@
+servers = "{{$.Env.REDIS_HOST}}";

--- a/filter/rootfs/usr/local/bin/entrypoint.sh
+++ b/filter/rootfs/usr/local/bin/entrypoint.sh
@@ -17,6 +17,8 @@ fi
 dockerize \
   -template /etc/rspamd/local.d/antivirus.conf.templ:/etc/rspamd/local.d/antivirus.conf \
   -template /etc/rspamd/local.d/worker-controller.inc.templ:/etc/rspamd/local.d/worker-controller.inc \
+  -template /etc/rspamd/override.d/redis.templ:/etc/rspamd/override.d/redis.conf \
+  -template /etc/rspamd/local.d/classifier-bayes.templ:/etc/rspamd/local.d/classifier-bayes.conf \
   ${FILTER_VIRUS_ARGS} \
   -timeout ${WAITSTART_TIMEOUT} \
   /usr/sbin/rspamd -c /etc/rspamd/rspamd.conf -f

--- a/mta/rootfs/usr/local/bin/entrypoint.sh
+++ b/mta/rootfs/usr/local/bin/entrypoint.sh
@@ -4,6 +4,8 @@ set -e
 postconf myhostname="${MAILNAME}"
 postconf mynetworks="${MYNETWORKS}"
 postconf recipient_delimiter="${RECIPIENT_DELIMITER}"
+postconf smtpd_milters="inet:${RSPAMD_HOST}:11332"
+postconf non_smtpd_milters="inet:${RSPAMD_HOST}:11332"
 
 if [ "${FILTER_MIME}" == "true" ]
 then

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,6 +21,7 @@ ENV MYSQL_HOST=db \
     MTA_HOST=mta \
     MDA_HOST=mda \
     FILTER_HOST=filter \
+    WEB_HOST=web \
     SUPPORT_URL=https://github.com/jeboehm/docker-mailserver \
     APP_ENV=prod \
     TRUSTED_PROXIES=172.16.0.0/12 \

--- a/web/rootfs/etc/nginx/sites-enabled/10-docker.templ
+++ b/web/rootfs/etc/nginx/sites-enabled/10-docker.templ
@@ -61,7 +61,7 @@ server {
     }
 
     location /rspamd/ {
-        proxy_pass http://filter:11334/;
+        proxy_pass http://{{ .Env.FILTER_HOST }}:11334/;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }

--- a/web/rootfs/usr/local/bin/entrypoint.sh
+++ b/web/rootfs/usr/local/bin/entrypoint.sh
@@ -32,7 +32,8 @@ dockerize \
   -wait tcp://${MTA_HOST}:25 \
   -wait tcp://${FILTER_HOST}:11334 \
   -wait file:///media/dkim/ \
-  -timeout ${WAITSTART_TIMEOUT}
+  -timeout ${WAITSTART_TIMEOUT} \
+  -template /etc/nginx/sites_enabled/10-docker.templ:/etc/nginx/sites_enabled/10-docker.conf
 
 manager_init
 roundcube_init

--- a/web/rootfs/usr/local/bin/fixtures.sh
+++ b/web/rootfs/usr/local/bin/fixtures.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 dockerize \
-  -wait tcp://web:80 \
+  -wait tcp://${WEB_HOST}:80 \
   -wait tcp://${MYSQL_HOST}:3306 \
   -timeout ${WAITSTART_TIMEOUT} \
   ${@}


### PR DESCRIPTION
Small changes to fully support changing docker-compose service names. It's usefull if you want to setup docker-mailserver with your existing configuration or if the service name (e.g. "redis" or "web") is already taken.

In addition to the existing variables:
- WEB_HOST
- REDIS_HOST