### PR TITLE
fix: sieve/rspamc errors

### DIFF
--- a/mda/rootfs/etc/dovecot/conf.d/90-sieve.conf
+++ b/mda/rootfs/etc/dovecot/conf.d/90-sieve.conf
@@ -1,20 +1,7 @@
+# This file is required by sievec to compile the sieve scripts with external plugins used.
+# It is overriden when the container starts.
+
 plugin {
   sieve_plugins = sieve_imapsieve sieve_extprograms
-  sieve_global_extensions = +vnd.dovecot.pipe
-  sieve = file:~/sieve;active=~/.dovecot.sieve
-  sieve_before = /etc/dovecot/sieve/global/spam-to-folder.sieve
-  sieve_pipe_bin_dir = /usr/lib/dovecot/sieve
-  sieve_pipe_exec_timeout = 60s
-  recipient_delimiter = -
-
-  # From somewhere to junk folder
-  imapsieve_mailbox1_name = Junk
-  imapsieve_mailbox1_causes = COPY
-  imapsieve_mailbox1_before = file:/etc/dovecot/sieve/global/learn-spam.sieve
-
-  # From junk folder to elsewhere
-  imapsieve_mailbox2_name = *
-  imapsieve_mailbox2_from = Junk
-  imapsieve_mailbox2_causes = COPY
-  imapsieve_mailbox2_before = file:/etc/dovecot/sieve/global/learn-ham.sieve
+  sieve_global_extensions = +vnd.dovecot.pipe +vnd.dovecot.environment
 }

--- a/mda/rootfs/etc/dovecot/conf.d/90-sieve.conf.templ
+++ b/mda/rootfs/etc/dovecot/conf.d/90-sieve.conf.templ
@@ -1,0 +1,23 @@
+plugin {
+  sieve_plugins = sieve_imapsieve sieve_extprograms
+  sieve_global_extensions = +vnd.dovecot.pipe +vnd.dovecot.environment
+  sieve = file:~/sieve;active=~/.dovecot.sieve
+  sieve_before = /etc/dovecot/sieve/global/spam-to-folder.sieve
+  sieve_pipe_bin_dir = /usr/lib/dovecot/sieve
+  sieve_pipe_exec_timeout = 60s
+  recipient_delimiter = -
+
+  # From somewhere to junk folder
+  imapsieve_mailbox1_name = Junk
+  imapsieve_mailbox1_causes = COPY
+  imapsieve_mailbox1_before = file:/etc/dovecot/sieve/global/learn-spam.sieve
+
+  # From junk folder to elsewhere
+  imapsieve_mailbox2_name = *
+  imapsieve_mailbox2_from = Junk
+  imapsieve_mailbox2_causes = COPY
+  imapsieve_mailbox2_before = file:/etc/dovecot/sieve/global/learn-ham.sieve
+
+  sieve_env_filter_host = {{ .Env.FILTER_HOST }}
+  sieve_env_controller_password = {{ .Env.CONTROLLER_PASSWORD }}
+}

--- a/mda/rootfs/etc/dovecot/sieve/global/learn-ham.sieve
+++ b/mda/rootfs/etc/dovecot/sieve/global/learn-ham.sieve
@@ -1,2 +1,2 @@
-require ["vnd.dovecot.pipe", "copy", "imapsieve"];
-pipe :copy "rspamc" ["learnham"];
+require ["vnd.dovecot.pipe", "copy", "imapsieve", "vnd.dovecot.environment", "variables"];
+pipe :copy "rspamc" ["learnham", "${env.vnd.dovecot.config.filter_host}", "${env.vnd.dovecot.config.controller_password}"];

--- a/mda/rootfs/etc/dovecot/sieve/global/learn-spam.sieve
+++ b/mda/rootfs/etc/dovecot/sieve/global/learn-spam.sieve
@@ -1,2 +1,2 @@
-require ["vnd.dovecot.pipe", "copy", "imapsieve"];
-pipe :copy "rspamc" ["learnspam"];
+require ["vnd.dovecot.pipe", "copy", "imapsieve", "vnd.dovecot.environment", "variables"];
+pipe :copy "rspamc" ["learnspam", "${env.vnd.dovecot.config.filter_host}", "${env.vnd.dovecot.config.controller_password}"];

--- a/mda/rootfs/usr/lib/dovecot/sieve/rspamc
+++ b/mda/rootfs/usr/lib/dovecot/sieve/rspamc
@@ -1,5 +1,18 @@
 #!/bin/sh
+set -e
 
-ACTION=${1}
+ACTION="${1}"
+HOST="${2}"
+PASSWORD="${3}"
 
-curl -q -s -H "Password: ${CONTROLLER_PASSWORD}" --connect-timeout 10 --data-binary @- http://${FILTER_HOST}:11334/${ACTION}
+if [ "${ACTION}" == "" ] || [ "${HOST}" == "" ] || [ "${PASSWORD}" == "" ]
+then
+    echo "Error: Missing parameters!"
+    echo
+    echo "Usage:"
+    echo "$0 <learnham|learnspam> <filter host> <controller password> < yourmail.txt"
+
+    exit 1
+fi
+
+curl -q -s -H "User: ${USER}" -H "Password: ${PASSWORD}" --connect-timeout 10 --data-binary @- http://${HOST}:11334/${ACTION}

--- a/mda/rootfs/usr/local/bin/entrypoint.sh
+++ b/mda/rootfs/usr/local/bin/entrypoint.sh
@@ -12,6 +12,7 @@ dockerize \
   -template /etc/dovecot/conf.d/10-master.conf.templ:/etc/dovecot/conf.d/10-master.conf \
   -template /etc/dovecot/conf.d/15-lda.conf.templ:/etc/dovecot/conf.d/15-lda.conf \
   -template /etc/dovecot/conf.d/20-submission.conf.templ:/etc/dovecot/conf.d/20-submission.conf \
+  -template /etc/dovecot/conf.d/90-sieve.conf.templ:/etc/dovecot/conf.d/90-sieve.conf \
   -template /etc/dovecot/dovecot-sql.conf.ext.templ:/etc/dovecot/dovecot-sql.conf.ext \
   -wait tcp://${MYSQL_HOST}:${MYSQL_PORT} \
   -wait file://${SSL_CERT} \


### PR DESCRIPTION
Since Dovecot is protecting the global environment variables,
the sieve script for learing ham / spam is modified to obtain its own set of variables