### PR TITLE
feat: Allow encrypted mail submission on port 465 (disabled by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,15 @@ Documentation
 Services
 --------
 
-| Service                           | Address                      |
-| --------------------------------- | ---------------------------- |
-| POP3 (starttls needed)            | 127.0.0.1:110                |
-| POP3S                             | 127.0.0.1:995                |
-| IMAP (starttls needed)            | 127.0.0.1:143                |
-| IMAPS                             | 127.0.0.1:993                |
-| SMTP                              | 127.0.0.1:25                 |
-| Mail Submission (starttls needed) | 127.0.0.1:587                |
-| Management Interface              | http://127.0.0.1:81/manager/ |
-| Webmail                           | http://127.0.0.1:81/webmail/ |
-| Rspamd Webinterface               | http://127.0.0.1:81/rspamd/  |
+| Service                                    | Address                      |
+| ------------------------------------------ | ---------------------------- |
+| POP3 (starttls needed)                     | 127.0.0.1:110                |
+| POP3S                                      | 127.0.0.1:995                |
+| IMAP (starttls needed)                     | 127.0.0.1:143                |
+| IMAPS                                      | 127.0.0.1:993                |
+| SMTP                                       | 127.0.0.1:25                 |
+| Mail Submission (starttls needed)          | 127.0.0.1:587                |
+| Mail Submission (SSL, disabled by default) | 127.0.0.1:465                |
+| Management Interface                       | http://127.0.0.1:81/manager/ |
+| Webmail                                    | http://127.0.0.1:81/webmail/ |
+| Rspamd Webinterface                        | http://127.0.0.1:81/rspamd/  |

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -12,6 +12,8 @@ services:
     ports:
       - "0.0.0.0:25:25"
       - "0.0.0.0:587:587"
+    # Uncomment to use SSL encrypted mail submission
+    #  - "0.0.0.0:465:465"
 
   web:
     ports:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
       - data-dkim:/media/dkim:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
       # For development
-      # - ./test/rootfs/usr/share/tests:/usr/share/tests:ro
+      - ./test/rootfs/usr/share/tests:/usr/share/tests:ro
     env_file: .env
 
   # For development

--- a/mta/Dockerfile
+++ b/mta/Dockerfile
@@ -67,6 +67,14 @@ RUN apk --no-cache add \
     echo " -o smtpd_recipient_restrictions=" >> /etc/postfix/master.cf && \
     echo " -o smtpd_sender_restrictions=reject_sender_login_mismatch,permit_sasl_authenticated,reject" >> /etc/postfix/master.cf && \
     echo " -o smtpd_relay_restrictions=permit_sasl_authenticated,reject" >> /etc/postfix/master.cf && \
+    echo " -o milter_macro_daemon_name=ORIGINATING" >> /etc/postfix/master.cf && \
+    echo "smtps inet n - n - - smtpd" >> /etc/postfix/master.cf && \
+    echo " -o syslog_name=postfix/smtps" >> /etc/postfix/master.cf && \
+    echo " -o smtpd_tls_wrappermode=yes" >> /etc/postfix/master.cf && \
+    echo " -o smtpd_reject_unlisted_recipient=no" >> /etc/postfix/master.cf && \
+    echo " -o smtpd_recipient_restrictions=" >> /etc/postfix/master.cf && \
+    echo " -o smtpd_sender_restrictions=reject_sender_login_mismatch,permit_sasl_authenticated,reject" >> /etc/postfix/master.cf && \
+    echo " -o smtpd_relay_restrictions=permit_sasl_authenticated,reject" >> /etc/postfix/master.cf && \
     echo " -o milter_macro_daemon_name=ORIGINATING" >> /etc/postfix/master.cf
 
 COPY --from=dockerize /usr/local/bin/dockerize /usr/local/bin

--- a/test/rootfs/usr/share/tests/040_mta.bats
+++ b/test/rootfs/usr/share/tests/040_mta.bats
@@ -1,38 +1,38 @@
 #!/usr/bin/env bats
 
 @test "send mail to local account address" {
-    run swaks -s mta --to admin@example.com --body "$BATS_TEST_DESCRIPTION"
+    run swaks -s mta --port 25 --to admin@example.com --body "$BATS_TEST_DESCRIPTION"
     [ "$status" -eq 0 ]
 }
 
 @test "send mail to local address with extension" {
-    run swaks -s mta --to admin-test@example.com --body "$BATS_TEST_DESCRIPTION"
+    run swaks -s mta --port 25 --to admin-test@example.com --body "$BATS_TEST_DESCRIPTION"
     [ "$status" -eq 0 ]
 }
 
 @test "send mail to unknown address (catchall)" {
-    run swaks -s mta --to notexisting@example.com --body "$BATS_TEST_DESCRIPTION"
+    run swaks -s mta --port 25 --to notexisting@example.com --body "$BATS_TEST_DESCRIPTION"
     [ "$status" -eq 0 ]
 }
 
 @test "send mail to unknown address should fail" {
-    run swaks -s mta --to notexisting@example.org --body "$BATS_TEST_DESCRIPTION"
+    run swaks -s mta --port 25 --to notexisting@example.org --body "$BATS_TEST_DESCRIPTION"
     [ "$status" -eq 24 ]
 }
 
 @test "send mail to local alias" {
-    run swaks -s mta --to foo@example.com --body "$BATS_TEST_DESCRIPTION"
+    run swaks -s mta --port 25 --to foo@example.com --body "$BATS_TEST_DESCRIPTION"
     [ "$status" -eq 0 ]
 }
 
 @test "send junk mail to local address" {
-    run swaks -s mta --to admin@example.com --body "$BATS_TEST_DESCRIPTION" --header "X-Spam: Yes"
+    run swaks -s mta --port 25 --to admin@example.com --body "$BATS_TEST_DESCRIPTION" --header "X-Spam: Yes"
     [ "$status" -eq 0 ]
 }
 
 @test "send mail with too big attachment to quota user" {
     dd if=/dev/urandom of=/tmp/bigfile bs=1M count=5
-    run swaks -s mta --to quota@example.com --body "$BATS_TEST_DESCRIPTION" --attach /tmp/bigfile
+    run swaks -s mta --port 25 --to quota@example.com --body "$BATS_TEST_DESCRIPTION" --attach /tmp/bigfile
     [ "$status" -eq 0 ]
 }
 
@@ -47,23 +47,18 @@
     [ "$status" -eq 0 ]
 }
 
-@test "authentification on smtp with disabled account should fail" {
+@test "authentification on smtp with disabled account should fail (submission service)" {
     run swaks -s mta --port 587 --to admin@example.com --from disabled@example.com -a -au disabled@example.com -ap test1234 -tls --body "$BATS_TEST_DESCRIPTION"
     [ "$status" -eq 28 ]
 }
 
-@test "authentification on smtp with disabled and send only account should fail" {
+@test "authentification on smtp with disabled and send only account should fail (submission service)" {
     run swaks -s mta --port 587 --to admin@example.com --from disabledsendonly@example.com -a -au disabled@example.com -ap test1234 -tls --body "$BATS_TEST_DESCRIPTION"
     [ "$status" -eq 28 ]
 }
 
 @test "send mail to mta with smtp authentification (submission service)" {
     run swaks -s mta --port 587 --to admin@example.com --from admin@example.com -a -au admin@example.com -ap changeme -tls --body "$BATS_TEST_DESCRIPTION"
-    [ "$status" -eq 0 ]
-}
-
-@test "send mail to mta with smtp authentification on port 25 (as long as this is not disabled)" {
-    run swaks -s mta --to admin@example.com --from admin@example.com -a -au admin@example.com -ap changeme -tls --body "$BATS_TEST_DESCRIPTION"
     [ "$status" -eq 0 ]
 }
 
@@ -94,6 +89,26 @@
 
 @test "send mail to mta without tls (submission service)" {
     run swaks -s mta --port 587 --to admin@example.com --from admin@example.com -a -au admin@example.com -ap changeme --body "$BATS_TEST_DESCRIPTION"
+    [ "$status" -eq 28 ]
+}
+
+@test "send mail to mta with smtp authentification on port 25 (as long as this is not disabled)" {
+    run swaks -s mta --port 25 --to admin@example.com --from admin@example.com -a -au admin@example.com -ap changeme -tls --body "$BATS_TEST_DESCRIPTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "send mail to mta with smtp authentification on port 25 with wrong credentials (as long as this is not disabled)" {
+    run swaks -s mta --port 25 --to admin@example.com --from admin@example.com -a -au unknown@example.com -ap changeme -tls --body "$BATS_TEST_DESCRIPTION"
+    [ "$status" -eq 28 ]
+}
+
+@test "send mail to mta with smtp authentification on port 465" {
+    run swaks -s mta --port 465 --to admin@example.com --from admin@example.com -a -au admin@example.com -ap changeme -tlsc --body "$BATS_TEST_DESCRIPTION"
+    [ "$status" -eq 0 ]
+}
+
+@test "send mail to mta with smtp authentification on port 465 with wrong credentials" {
+    run swaks -s mta --port 465 --to admin@example.com --from admin@example.com -a -au unknown@example.com -ap changeme -tlsc --body "$BATS_TEST_DESCRIPTION"
     [ "$status" -eq 28 ]
 }
 


### PR DESCRIPTION
The port forwarding has to be enabled in docker-compose.production.yml.
Fixes #146