### PR TITLE
fix: prevent admin from deleting migrations table

### DIFF
--- a/.github/workflows/sync-branch.yml
+++ b/.github/workflows/sync-branch.yml
@@ -1,0 +1,21 @@
+name: Sync branch main to next
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-branch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Sync branch main to next
+      uses: devmasx/merge-branch@1.4.0
+      with:
+        from_branch: 'main'
+        target_branch: 'next'
+        type: now
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/web/rootfs/usr/local/bin/entrypoint.sh
+++ b/web/rootfs/usr/local/bin/entrypoint.sh
@@ -5,14 +5,13 @@ manager_init() {
   cd /opt/manager
 
   bin/console doctrine:migrations:migrate -n
-  bin/console doctrine:schema:update --force
 }
 
 roundcube_init() {
   cd /var/www/html/webmail
-  PWD=`pwd`
+  PWD=$(pwd)
 
-  bin/initdb.sh --dir=$PWD/SQL || bin/updatedb.sh --dir=$PWD/SQL --package=roundcube || echo "Failed to initialize databse. Please run $PWD/bin/initdb.sh manually."
+  bin/initdb.sh --dir="$PWD/SQL" || bin/updatedb.sh --dir="$PWD/SQL" --package=roundcube || echo "Failed to initialize databse. Please run $PWD/bin/initdb.sh manually."
   rm -f /var/www/html/webmail/logs/errors.log
 }
 
@@ -28,12 +27,12 @@ dkim_refresh() {
 }
 
 dockerize \
-  -wait tcp://${MYSQL_HOST}:${MYSQL_PORT} \
-  -wait tcp://${MDA_HOST}:143 \
-  -wait tcp://${MTA_HOST}:25 \
-  -wait tcp://${FILTER_HOST}:11334 \
+  -wait "tcp://${MYSQL_HOST}:${MYSQL_PORT}" \
+  -wait "tcp://${MDA_HOST}:143" \
+  -wait "tcp://${MTA_HOST}:25" \
+  -wait "tcp://${FILTER_HOST}:11334" \
   -wait file:///media/dkim/ \
-  -timeout ${WAITSTART_TIMEOUT} \
+  -timeout "${WAITSTART_TIMEOUT}" \
   -template /etc/nginx/nginx.conf.templ:/etc/nginx/nginx.conf \
   -template /var/www/html/autoconfig/config-v1.1.xml.templ:/var/www/html/autoconfig/config-v1.1.xml
 
@@ -42,6 +41,7 @@ roundcube_init
 permissions
 dkim_refresh
 
-export APP_SECRET=`echo $RANDOM | md5sum | head -c 20`
+# shellcheck disable=SC3028,SC2155
+export APP_SECRET="$(echo $RANDOM | md5sum | head -c 20)"
 
 /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
Prevents mailserver-admin from deleting the migrations table.

```
[error] Migration DoctrineMigrations\Version20180320164351 failed during Pre-Checks. Error: "An exception occurred while executing a query: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'mailserver.virtual_users' doesn't exist"
[critical] Error thrown while running command "doctrine:migrations:migrate -n". Message: "An exception occurred while executing a query: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'mailserver.virtual_users' doesn't exist"

In ExceptionConverter.php line 40:
                                                                               
  An exception occurred while executing a query: SQLSTATE[42S02]: Base table   
  or view not found: 1146 Table 'mailserver.virtual_users' doesn't exist       
                                                                               

In Exception.php line 28:
                                                                               
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'mailserver.virtu  
  al_users' doesn't exist                                                      
                                                                               

In Connection.php line 57:
                                                                               
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'mailserver.virtu  
  al_users' doesn't exist                                                      
```

Fix:
- restart container
- run sql:

```
INSERT INTO `migration_versions` (
    `version`, `executed_at`, `execution_time`
) VALUES
('DoctrineMigrations\\Version20180320164351', NOW(), 0),
('DoctrineMigrations\\Version20180320171339', NOW(), 0),
('DoctrineMigrations\\Version20180322081734', NOW(), 0),
('DoctrineMigrations\\Version20180520173959', NOW(), 0),
('DoctrineMigrations\\Version20190610121554', NOW(), 0);
```