### PR TITLE
Configure traefik ingress for mta mda and kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,3 +108,24 @@ kubernetes-test:
 	kubectl wait --timeout=10m --for=condition=complete job -l app.kubernetes.io/name=test-runner-job
 	kubectl logs --ignore-errors -l app.kubernetes.io/name=test-runner-job
 
+.PHONY: kind-provision
+kind-provision:
+	kind create cluster --name mail --wait 60s
+
+.PHONY: kind-load
+kind-load: build
+	kind load docker-image jeboehm/mailserver-mda:latest
+	kind load docker-image jeboehm/mailserver-mta:latest
+	kind load docker-image jeboehm/mailserver-filter:latest
+	kind load docker-image jeboehm/mailserver-web:latest
+	kind load docker-image jeboehm/mailserver-unbound:latest
+
+.PHONY: kind-up
+kind-up:
+	kubectl apply -k .
+
+.PHONY: kind-test
+kind-test:
+	kubectl delete -f test/bats/job.yaml --ignore-not-found
+	kubectl apply -f test/bats/job.yaml
+

--- a/deploy/kustomize/kustomization.yaml
+++ b/deploy/kustomize/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - redis/
   - unbound/
   - web/
+  - traefik-tcp/

--- a/deploy/kustomize/traefik-tcp/ingressroutes.yaml
+++ b/deploy/kustomize/traefik-tcp/ingressroutes.yaml
@@ -1,0 +1,59 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: imap
+  labels:
+    app.kubernetes.io/part-of: docker-mailserver
+spec:
+  entryPoints:
+    - imap
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: mda
+          port: imap
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: imaps
+  labels:
+    app.kubernetes.io/part-of: docker-mailserver
+spec:
+  entryPoints:
+    - imaps
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: mda
+          port: imaps
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: smtp
+  labels:
+    app.kubernetes.io/part-of: docker-mailserver
+spec:
+  entryPoints:
+    - smtp
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: mta
+          port: smtp
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: submission
+  labels:
+    app.kubernetes.io/part-of: docker-mailserver
+spec:
+  entryPoints:
+    - submission
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: mta
+          port: submission

--- a/deploy/kustomize/traefik-tcp/kustomization.yaml
+++ b/deploy/kustomize/traefik-tcp/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ingressroutes.yaml


### PR DESCRIPTION
Add Traefik IngressRouteTCP manifests for mail services and new Makefile targets for Kind cluster management.

The `IngressRouteTCP` resources expose IMAP, IMAPS, SMTP, and Submission ports for `mda` and `mta` services, assuming Traefik is configured with corresponding TCP entryPoints. The new `kind-*` Makefile targets streamline the setup, deployment, and testing of the application within a local Kind cluster.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4b4fda0-ea6f-4743-9260-78f3f32cf0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4b4fda0-ea6f-4743-9260-78f3f32cf0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

