### PR TITLE
Enable unbound dns request logging

### DIFF
--- a/target/unbound/rootfs/etc/unbound/unbound.conf
+++ b/target/unbound/rootfs/etc/unbound/unbound.conf
@@ -9,7 +9,7 @@ server:
     access-control: 0.0.0.0/0 allow
     use-syslog: no
     logfile: ""
-    #log-queries: yes
+    log-queries: yes
     #log-replies: yes
 
 remote-control:


### PR DESCRIPTION
Enable DNS query logging in Unbound by uncommenting `log-queries: yes`.

---
<a href="https://cursor.com/background-agent?bcId=bc-1da7fb54-d944-4e9f-ad08-0d667cc42b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1da7fb54-d944-4e9f-ad08-0d667cc42b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

