### PR TITLE
chore(ci): split build and manifest testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,30 +283,3 @@ jobs:
         run: |
           make kubernetes-logs
           kubectl get pods -o wide
-  test_kustomize_build:
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
-      - name: Run kustomize build
-        run: |
-          make .env
-          kustomize build .
-  test_yaml_schema:
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: test/pajv/package-lock.json
-      - name: Install packages
-        run: |
-          cd test/pajv
-          npm install
-      - name: Run yaml schema test
-        run: |
-          cd test/pajv
-          ./run-tests.sh

--- a/.github/workflows/test-yaml-schema.yml
+++ b/.github/workflows/test-yaml-schema.yml
@@ -1,0 +1,35 @@
+name: Test YAML manifests
+on:
+  pull_request:
+    paths:
+      - "test/pajv/**"
+      - "deploy/**"
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  test_kustomize_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+      - name: Run kustomize build
+        run: |
+          make .env
+          kustomize build .
+  test_yaml_schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: test/pajv/package-lock.json
+      - name: Install packages
+        run: |
+          cd test/pajv
+          npm install
+      - name: Run yaml schema test
+        run: |
+          cd test/pajv
+          ./run-tests.sh

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Container images are built on [Alpine Linux](https://alpinelinux.org) or vendor 
 [Changelog](https://github.com/jeboehm/docker-mailserver/releases)
 [Upgrade Guide](docs/UPGRADE.md)
 
-[![Tests](https://github.com/jeboehm/docker-mailserver/actions/workflows/test.yml/badge.svg?branch=next)](https://github.com/jeboehm/docker-mailserver/actions/workflows/test.yml)
-[![Build](https://github.com/jeboehm/docker-mailserver/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/jeboehm/docker-mailserver/actions/workflows/build.yml)
+[![Build & Tests](https://github.com/jeboehm/docker-mailserver/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/jeboehm/docker-mailserver/actions/workflows/build.yml)
 
 ## Features
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extracts Kubernetes manifest tests into a new workflow and removes them from the main build pipeline; updates README to a single build/tests badge.
> 
> - **CI**:
>   - Split manifest validation into `/.github/workflows/test-yaml-schema.yml` with:
>     - `test_kustomize_build`: runs `kustomize build`.
>     - `test_yaml_schema`: installs Node deps and runs schema tests in `test/pajv`.
>   - Removed `test_kustomize_build` and `test_yaml_schema` jobs from `/.github/workflows/build.yml`.
> - **Docs**:
>   - Consolidated README badges into a single "Build & Tests" badge pointing to `build.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b98c08bc5e9236611886c1e519c3eff5c0511dc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->