### PR TITLE
feat(web): use release artifact from docker-mailserver

### DIFF
--- a/target/web/Dockerfile
+++ b/target/web/Dockerfile
@@ -76,7 +76,7 @@ RUN --mount=type=cache,target=/root/.composer \
 
 FROM composer AS admin-builder
 
-ARG ADMIN_VER=5.6.2 # renovate: depName=jeboehm/mailserver-admin
+ARG ADMIN_VER=5.6.4 # renovate: depName=jeboehm/mailserver-admin
 WORKDIR /opt/manager
 RUN curl -sSLf \
         -o /tmp/admin.tar.gz \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors the web image to a multi-stage build, switches admin to the release artifact (v5.6.4), and optimizes Roundcube and ownership setup.
> 
> - **Dockerfile (`target/web/Dockerfile`)**:
>   - **Build Refactor**: Convert to multi-stage (`builder` → `composer` → `roundcube-builder` → `admin-builder` → `prod`); install `@composer` in a dedicated stage.
>   - **Roundcube**:
>     - Copy from `roundcube/roundcubemail:1.6.11-fpm`.
>     - Run `composer install --no-dev -o --apcu-autoloader --ignore-platform-reqs`; remove `composer.lock`; create `temp/` and `logs/`.
>   - **Admin**:
>     - Bump `ADMIN_VER` to `5.6.4`.
>     - Fetch release artifact (`release-${ADMIN_VER}.tar.gz`) instead of source archive; run `composer symfony:dump-env prod` (no app install step).
>   - **Final Image Assembly**:
>     - Copy built `webmail/` and `/opt/manager/` into final stage.
>     - Set ownership for `webmail/temp`, `webmail/logs`, and `manager` caches/logs; symlink `manager` to `/var/www/html/manager`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3381bdceea328ccc386d9a3de23dc17d273508d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->