### PR TITLE
fix: remove dockerize from mda image

### DIFF
--- a/target/mda/Dockerfile
+++ b/target/mda/Dockerfile
@@ -1,44 +1,42 @@
-FROM ghcr.io/jeboehm/dockerize:0.9.3@sha256:d4e824aa120670658d7012421d2fdf1b2437be34a6acbb7a4ad92ed52edec8eb AS dockerize
 FROM dovecot/dovecot:2.4.1-dev@sha256:99f45812578122e62663503f55bd32919e96c7b048349539a8511c3e71c00e3e
 
 LABEL maintainer="https://github.com/jeboehm/docker-mailserver"
 LABEL vendor="https://github.com/jeboehm/docker-mailserver"
 LABEL de.ressourcenkonflikt.docker-mailserver.autoheal="true"
 
-USER root
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y curl && \
-    rm -rf \
-        /etc/dovecot/conf.d/mail.conf \
-        /etc/dovecot/conf.d/ssl.conf \
-        /var/lib/apt/lists/*
-USER vmail
-
 ENV MYSQL_HOST=db \
     MYSQL_PORT=3306 \
     MYSQL_USER=root \
     MYSQL_DATABASE=mailserver \
     FILTER_WEB_ADDRESS=filter:11334 \
-    MTA_SMTP_ADDRESS=mta:25 \
-    RECIPIENT_DELIMITER=- \
     MAILNAME=mail.example.com \
     MDA_UPSTREAM_PROXY=no \
+    MTA_SMTP_ADDRESS=mta:25 \
     POSTMASTER=postmaster@example.com \
-    WAITSTART_TIMEOUT=1m
-
-# 2003: LMTP, 2004: AUTH
-EXPOSE 2003 2004
-
-COPY --chown=root:root --from=dockerize /bin/dockerize /bin/dockerize
-COPY --chown=root:root rootfs/ /
+    RECIPIENT_DELIMITER=-
 
 USER root
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y curl && \
+    rm -rf \
+        /etc/dovecot/conf.d/auth.conf \
+        /etc/dovecot/conf.d/mail.conf \
+        /etc/dovecot/conf.d/ssl.conf \
+        /srv/mail \
+        /var/lib/apt/lists/*
+
+COPY --chown=root:root rootfs/ /
+
 WORKDIR /etc/dovecot/sieve/global
 RUN mv /etc/dovecot/conf.d/10-ssl.conf /tmp/10-ssl.conf && \
     sievec . && \
     mv /tmp/10-ssl.conf /etc/dovecot/conf.d/10-ssl.conf
+
 USER vmail
 WORKDIR /
+
+# 2003: LMTP, 2004: AUTH
+EXPOSE 2003 2004
 
 HEALTHCHECK CMD /usr/local/bin/healthcheck.sh
 

--- a/target/mda/rootfs/entrypoint.sh
+++ b/target/mda/rootfs/entrypoint.sh
@@ -25,7 +25,4 @@ if ! [ -r /etc/dovecot/tls/tls.crt ] || ! [ -r /etc/dovecot/tls/tls.key ]; then
 	exit 1
 fi
 
-exec dockerize \
-	-wait "tcp://${MYSQL_HOST}:${MYSQL_PORT}" \
-	-timeout "${WAITSTART_TIMEOUT}" \
-	/dovecot/sbin/dovecot -F
+exec /usr/bin/tini -- /dovecot/sbin/dovecot -F


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes dependency on dockerize and updates image build/startup.
> 
> - Switches base to `dovecot/dovecot:2.4.1-dev`; drops multistage `dockerize` layer and binary
> - Replaces dockerize wait/entrypoint with `tini` launching `dovecot -F`; removes `WAITSTART_TIMEOUT`
> - Adjusts Dockerfile: perform setup as `root`, install `curl`, and remove extra Dovecot configs (`auth.conf`, `mail.conf`, `ssl.conf`) and `/srv/mail`
> - Retains key env (`MTA_SMTP_ADDRESS`, `RECIPIENT_DELIMITER`); ports and healthcheck remain the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c706963c5bd3c6a90672383cf22bc222fdc6719. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->