### PR TITLE
feat(web): upgrade to mailserver-admin 5.13

### DIFF
--- a/.mkdocs.yaml
+++ b/.mkdocs.yaml
@@ -39,6 +39,7 @@ nav:
       - administration/dkim-signing.md
       - administration/dns-validation-wizard.md
       - administration/user-roles.md
+      - administration/ios-macos-profile.md
   - Recipes:
       - Docker:
           - Traefik Reverse Proxy: https://github.com/jeboehm/docker-mailserver/tree/main/docs/example-configs/compose/traefik-reverse-proxy

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The documentation includes:
 - Restriction of sender addresses for enhanced security
 - Full-text search and enforced TLS
 - DNS Validation Wizard for all mail related DNS records
+- Generates configuration profiles for iOS and macOS devices
+- Supports assisted client configuration in Outlook and Thunderbird
 - Continuous health monitoring
 
 See the [documentation](https://jeboehm.github.io/docker-mailserver/) for a complete feature list.
@@ -62,7 +64,7 @@ For detailed installation instructions, see the [Installation Guide](https://jeb
 
 ### DNS Validation Wizard
 
-![DNS Validation Wizard](docs/images/admin/dns_validation_wizard.png)
+![DNS Validation Wizard](docs/images/admin/dns_wizard.png)
 
 ## Links
 

--- a/deploy/compose/web.yaml
+++ b/deploy/compose/web.yaml
@@ -24,6 +24,9 @@ services:
       - /opt/roundcube/temp:mode=0777
       - /opt/roundcube/logs:mode=0777
       - /tmp:mode=0777
-    # For use with jwilder/nginx-proxy.
-    # environment:
-    #   - VIRTUAL_HOST=mail.example.com
+    volumes:
+      - data-tls:/opt/admin/tls:ro
+      # For using external certificates uncomment the following lines
+      # and change the path on the left side of the colon.
+      # - /home/user/certs/mail.example.com.crt:/opt/admin/tls/tls.crt:ro
+      # - /home/user/certs/mail.example.com.key:/opt/admin/tls/tls.key:ro

--- a/deploy/kustomize/web/deployment.yaml
+++ b/deploy/kustomize/web/deployment.yaml
@@ -97,6 +97,8 @@ spec:
             - name: tmp
               mountPath: /opt/roundcube/logs
               subPath: rc-logs
+            - name: tls-certs
+              mountPath: /opt/admin/tls
       initContainers:
         - name: prepare-service
           image: jeboehm/mailserver-web:latest
@@ -145,5 +147,13 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       volumes:
+        - name: tls-certs
+          secret:
+            items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+            secretName: tls-certs
         - name: tmp
           emptyDir: {}

--- a/docs/administration/ios-macos-profile.md
+++ b/docs/administration/ios-macos-profile.md
@@ -1,0 +1,8 @@
+# iOS / macOS Profile
+
+The iOS / macOS Profile feature generates configuration profiles for Apple Mail on iOS and macOS devices. These profiles automatically configure IMAP and SMTP access, eliminating the need for manual email account setup.
+
+Please refer to Apple's documentation for more information.
+
+- [MacOS documentation](https://support.apple.com/en-us/guide/mac-help/mh35561/mac)
+- [iOS documentation](https://support.apple.com/en-us/102400)

--- a/docs/administration/user-roles.md
+++ b/docs/administration/user-roles.md
@@ -34,6 +34,7 @@ In `mailserver-admin`, there are three distinct user roles, each with different 
 
 - Login to the application
 - Configure and manage their personal fetchmail accounts
+- Change their own password with strict password policy
 
 **Restrictions**:
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -4,6 +4,10 @@ Upgrade guide for docker-mailserver.
 
 When upgrading, ensure that container configuration files are updated to match the requirements of the new version. Review the manifests in `deploy/compose` and `deploy/kustomize` for any changes to persistent volumes or configuration, and update them as necessary. If new environment variables have been introduced, update the `.env` file accordingly.
 
+## v7.1
+
+- **web**: mailserver-admin now includes a feature to generate mobileconfig files for iOS and macOS. These files are signed with the same TLS certificate that the mailserver displays to connecting clients. To generate these files, it’s necessary to mount the certificate to the web container.
+
 ## v6.x to v7.x
 
 The web image is now based on Alpine Linux and uses FrankenPHP instead of PHP-FPM.

--- a/target/web/Dockerfile
+++ b/target/web/Dockerfile
@@ -74,7 +74,7 @@ RUN --mount=type=cache,target=/root/.composer \
 
 FROM composer AS admin-builder
 
-ARG ADMIN_VER=5.12.0 # renovate: depName=jeboehm/mailserver-admin
+ARG ADMIN_VER=5.13.0 # renovate: depName=jeboehm/mailserver-admin
 WORKDIR /opt/admin
 RUN curl -sSLf \
         -o /tmp/admin.tar.gz \

--- a/test/bats/integration/050_web.bats
+++ b/test/bats/integration/050_web.bats
@@ -6,7 +6,7 @@ setup() {
 }
 
 @test "http connection to manager web interface" {
-	run curl -L "http://${WEB_HTTP_ADDRESS}/manager/"
+	run curl -L "http://${WEB_HTTP_ADDRESS}/"
 	assert_output --partial "Email address"
 }
 
@@ -21,6 +21,11 @@ setup() {
 }
 
 @test "http connection to autoconfigure file" {
-	run curl "http://${WEB_HTTP_ADDRESS}/.well-known/autoconfig/mail/config-v1.1.xml"
+	run curl "http://${WEB_HTTP_ADDRESS}/mail/config-v1.1.xml"
 	assert_output --partial "clientConfig"
+}
+
+@test "http connection to autodiscover file" {
+	run curl "http://${WEB_HTTP_ADDRESS}/autodiscover/autodiscover.xml"
+	assert_output --partial "DomainRequired"
 }


### PR DESCRIPTION
mailserver-admin now includes a feature to generate mobileconfig files for iOS and macOS. These files are signed with the same TLS certificate that the mailserver displays to connecting clients. To generate these files, it’s necessary to mount the certificate to the web container.

closes #645