### PR TITLE
feat(mda): enable trash plugin

### DIFF
--- a/target/mda/rootfs/etc/dovecot/conf.d/15-mailboxes.conf
+++ b/target/mda/rootfs/etc/dovecot/conf.d/15-mailboxes.conf
@@ -8,12 +8,14 @@ namespace inbox {
     auto = subscribe
     special_use = \Junk
     autoexpunge = 30d
+    trash_priority = 1
   }
 
   mailbox Trash {
     auto = subscribe
     special_use = \Trash
     autoexpunge = 30d
+    trash_priority = 2
   }
 
   mailbox Sent {

--- a/target/mda/rootfs/etc/dovecot/conf.d/90-quota.conf
+++ b/target/mda/rootfs/etc/dovecot/conf.d/90-quota.conf
@@ -1,5 +1,6 @@
 mail_plugins {
   quota = yes
+  trash = yes
 }
 
 protocol imap {


### PR DESCRIPTION
Normally, a quota exceeded error is returned if saving/copying a message would bring the user over quota. With the trash plugin, the oldest messages are instead expunged from the specified mailboxes until the message can be saved. If the new message is large enough that it wouldn't fit even if all messages from configured mailboxes were expunged, then no messages are expunged and the user receives a "Quota exceeded" error.