### PR TITLE
chore(ci): add manual workflow_dispatch trigger for forced releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,17 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Release type to force (patch, minor, major)"
+        required: false
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
@@ -20,7 +31,8 @@ jobs:
         uses: TriPSs/conventional-changelog-action@91be4f3188da74fe85de9caffcebc80b26d43b5b # v6
         with:
           github-token: ${{ secrets.GH_RELEASE_PAT }}
-          skip-on-empty: true
+          skip-on-empty: ${{ github.event_name != 'workflow_dispatch' }}
+          release-type: ${{ github.event.inputs.release_type || 'patch' }}
           git-push: false
           skip-git-pull: true
           skip-version-file: true


### PR DESCRIPTION
Allows triggering a release manually via GitHub Actions UI, bypassing the empty-changelog skip logic. Useful for forcing a bugfix release when no conventional commits are present.