### PR TITLE
fix(mta): harden smtpd against smuggling and early spam

### DIFF
--- a/target/mta/Dockerfile
+++ b/target/mta/Dockerfile
@@ -71,6 +71,10 @@ RUN --mount=type=cache,target=/var/cache/apk \
     postconf smtpd_hard_error_limit=5 && \
     postconf disable_vrfy_command=yes && \
     postconf smtpd_helo_required=yes && \
+    postconf smtpd_forbid_bare_newline=yes && \
+    postconf 'smtpd_forbid_bare_newline_exclusions=$mynetworks' && \
+    postconf smtpd_helo_restrictions="permit_mynetworks, permit_sasl_authenticated, reject_invalid_helo_hostname" && \
+    postconf smtpd_data_restrictions="permit_mynetworks, permit_sasl_authenticated, reject_unauth_pipelining" && \
     postconf local_recipient_maps = && \
     postconf local_transport = "error:local mail delivery is disabled" && \
     newaliases


### PR DESCRIPTION
Add the SMTP smuggling mitigation and two low-risk early-rejection restrictions to the Postfix build config:

- smtpd_forbid_bare_newline=yes (with $mynetworks excluded) closes the SMTP smuggling vector (https://www.postfix.org/smtp-smuggling.html)
- smtpd_helo_restrictions rejects syntactically invalid HELO hostnames, while permit_sasl_authenticated exempts authenticated submission users
- smtpd_data_restrictions rejects unauthorized SMTP pipelining

Addresses #801. The remaining settings proposed there are already set, equal to Postfix defaults, or intentionally left to Rspamd/DMARC.